### PR TITLE
CS-1372 Allow descriptor-related writes to MongoDB participate in a t…

### DIFF
--- a/extremum-common-starter/src/main/java/io/extremum/common/collection/service/ReactiveCollectionDescriptorService.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/collection/service/ReactiveCollectionDescriptorService.java
@@ -10,5 +10,7 @@ import reactor.core.publisher.Mono;
 public interface ReactiveCollectionDescriptorService {
     Mono<CollectionDescriptor> retrieveByExternalId(String externalId);
 
+    Mono<Descriptor> retrieveByCoordinates(CollectionDescriptor collectionDescriptor);
+
     Mono<Descriptor> retrieveByCoordinatesOrCreate(CollectionDescriptor collectionDescriptor);
 }

--- a/extremum-common-starter/src/main/java/io/extremum/common/collection/service/ReactiveCollectionDescriptorServiceImpl.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/collection/service/ReactiveCollectionDescriptorServiceImpl.java
@@ -29,11 +29,15 @@ public class ReactiveCollectionDescriptorServiceImpl implements ReactiveCollecti
     }
 
     @Override
+    public Mono<Descriptor> retrieveByCoordinates(CollectionDescriptor collectionDescriptor) {
+        return Mono.defer(() -> retrieveByCoordinates(collectionDescriptor.toCoordinatesString()));
+    }
+
+    @Override
     public Mono<Descriptor> retrieveByCoordinatesOrCreate(CollectionDescriptor collectionDescriptor) {
         Descriptor descriptor = descriptorSavers.createCollectionDescriptor(collectionDescriptor);
         return reactiveDescriptorDao.store(descriptor)
-                .onErrorResume(DuplicateKeyException.class,
-                        e -> retrieveByCoordinates(collectionDescriptor.toCoordinatesString()));
+                .onErrorResume(DuplicateKeyException.class, e -> retrieveByCoordinates(collectionDescriptor));
     }
 
     private Mono<Descriptor> retrieveByCoordinates(String coordinatesString) {

--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/BaseReactiveDescriptorDao.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/BaseReactiveDescriptorDao.java
@@ -4,7 +4,11 @@ import io.extremum.common.descriptor.dao.ReactiveDescriptorDao;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RMapReactive;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseUtils;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.transaction.reactive.TransactionSynchronization;
+import org.springframework.transaction.reactive.TransactionSynchronizationManager;
 import reactor.core.publisher.Mono;
 
 import java.util.Collection;
@@ -19,15 +23,18 @@ public abstract class BaseReactiveDescriptorDao implements ReactiveDescriptorDao
     private final RMapReactive<String, String> internalIdIndex;
     private final RMapReactive<String, String> collectionCoordinatesToExternalIds;
     private final ReactiveMongoOperations reactiveMongoOperations;
+    private final ReactiveMongoDatabaseFactory mongoDatabaseFactory;
 
     BaseReactiveDescriptorDao(RMapReactive<String, Descriptor> descriptors,
                               RMapReactive<String, String> internalIdIndex,
                               RMapReactive<String, String> collectionCoordinatesToExternalIds,
-                              ReactiveMongoOperations reactiveMongoOperations) {
+                              ReactiveMongoOperations reactiveMongoOperations,
+                              ReactiveMongoDatabaseFactory mongoDatabaseFactory) {
         this.descriptors = descriptors;
         this.internalIdIndex = internalIdIndex;
         this.collectionCoordinatesToExternalIds = collectionCoordinatesToExternalIds;
         this.reactiveMongoOperations = reactiveMongoOperations;
+        this.mongoDatabaseFactory = mongoDatabaseFactory;
     }
 
     @Override
@@ -50,7 +57,28 @@ public abstract class BaseReactiveDescriptorDao implements ReactiveDescriptorDao
     @Override
     public Mono<Descriptor> store(Descriptor descriptor) {
         return reactiveMongoOperations.save(descriptor)
-                .flatMap(savedToMongo -> putToMaps(savedToMongo).thenReturn(savedToMongo));
+                .flatMap(this::putToMapsAfterWriteToMongoBecomesVisible);
+    }
+
+    private Mono<Descriptor> putToMapsAfterWriteToMongoBecomesVisible(Descriptor savedToMongo) {
+        return ReactiveMongoDatabaseUtils.isTransactionActive(mongoDatabaseFactory).flatMap(inTransaction -> {
+            if (inTransaction) {
+                return putToMapsAfterTransactionCommit(savedToMongo);
+            } else {
+                return putToMaps(savedToMongo).thenReturn(savedToMongo);
+            }
+        });
+    }
+
+    private Mono<? extends Descriptor> putToMapsAfterTransactionCommit(Descriptor savedToMongo) {
+        return TransactionSynchronizationManager.forCurrentTransaction()
+                .doOnNext(tsm -> tsm.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public Mono<Void> afterCommit() {
+                        return putToMaps(savedToMongo);
+                    }
+                }))
+                .thenReturn(savedToMongo);
     }
 
     private Mono<Void> putToMaps(Descriptor descriptor) {

--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/BaseReactiveDescriptorDaoImpl.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/BaseReactiveDescriptorDaoImpl.java
@@ -7,6 +7,7 @@ import org.redisson.api.RedissonReactiveClient;
 import org.redisson.client.codec.Codec;
 import org.redisson.client.codec.StringCodec;
 import org.redisson.codec.CompositeCodec;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 
 import java.util.concurrent.TimeUnit;
@@ -15,6 +16,7 @@ public class BaseReactiveDescriptorDaoImpl extends BaseReactiveDescriptorDao {
     public BaseReactiveDescriptorDaoImpl(RedissonReactiveClient redissonClient,
                                          DescriptorRepository descriptorRepository,
                                          ReactiveMongoOperations reactiveMongoOperations,
+                                         ReactiveMongoDatabaseFactory mongoDatabaseFactory,
                                          String descriptorsMapName, String internalIdsMapName,
                                          String collectionCoordinatesMapName,
                                          int cacheSize, long idleTime) {
@@ -54,7 +56,7 @@ public class BaseReactiveDescriptorDaoImpl extends BaseReactiveDescriptorDao {
                                 .maxIdle(idleTime, TimeUnit.DAYS)
                                 .syncStrategy(LocalCachedMapOptions.SyncStrategy.NONE)),
 
-                reactiveMongoOperations);
+                reactiveMongoOperations, mongoDatabaseFactory);
     }
 
     private static Codec stringToStringCodec() {

--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/DescriptorCodecs.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/dao/impl/DescriptorCodecs.java
@@ -5,8 +5,8 @@ import io.extremum.sharedmodels.descriptor.Descriptor;
 import org.redisson.client.codec.Codec;
 import org.redisson.codec.TypedJsonJacksonCodec;
 
-class DescriptorCodecs {
-    static Codec codecForDescriptor() {
+public class DescriptorCodecs {
+    public static Codec codecForDescriptor() {
         return new TypedJsonJacksonCodec(String.class, Descriptor.class,
                 new BasicJsonObjectMapper());
     }

--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/factory/ReactiveDescriptorSaver.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/factory/ReactiveDescriptorSaver.java
@@ -1,5 +1,6 @@
 package io.extremum.common.descriptor.factory;
 
+import io.extremum.common.collection.service.ReactiveCollectionDescriptorService;
 import io.extremum.common.descriptor.service.DescriptorService;
 import io.extremum.common.descriptor.service.ReactiveDescriptorService;
 import io.extremum.sharedmodels.descriptor.CollectionDescriptor;
@@ -10,35 +11,49 @@ import reactor.core.publisher.Mono;
 
 public class ReactiveDescriptorSaver {
     private final ReactiveDescriptorService reactiveDescriptorService;
+    private final ReactiveCollectionDescriptorService reactiveCollectionDescriptorService;
 
     private final DescriptorSavers savers;
 
     public ReactiveDescriptorSaver(DescriptorService descriptorService,
-                                   ReactiveDescriptorService reactiveDescriptorService) {
+            ReactiveDescriptorService reactiveDescriptorService,
+            ReactiveCollectionDescriptorService reactiveCollectionDescriptorService) {
         this.reactiveDescriptorService = reactiveDescriptorService;
         savers = new DescriptorSavers(descriptorService);
+        this.reactiveCollectionDescriptorService = reactiveCollectionDescriptorService;
     }
 
     public Mono<Descriptor> createAndSave(String internalId, String modelType, StorageType storageType) {
         Descriptor descriptor = savers.createSingleDescriptor(internalId, modelType, storageType);
 
-        return createOrGet(descriptor);
-    }
-
-    public Mono<Descriptor> createAndSave(CollectionDescriptor collectionDescriptor) {
-        Descriptor descriptor = savers.createCollectionDescriptor(collectionDescriptor);
-        return createOrGet(descriptor);
-    }
-
-    private Mono<Descriptor> createOrGet(Descriptor descriptor) {
-        return reactiveDescriptorService.store(descriptor)
+        // Loading first to avoid a DuplicateKeyException which aborts a transaction.
+        // This is needed to be able to use descriptors under transaction.
+        return reactiveDescriptorService.loadByInternalId(descriptor.getInternalId())
+                .switchIfEmpty(reactiveDescriptorService.store(descriptor))
                 .onErrorResume(DuplicateKeyException.class,
                         ex -> reactiveDescriptorService.loadByInternalId(descriptor.getInternalId()))
                 .switchIfEmpty(Mono.defer(() -> Mono.error(
-                        new IllegalStateException(String.format("Could not insert nor retrive by internal ID: " +
+                        new IllegalStateException(String.format("Could not insert nor retrieve by internal ID: " +
                                 "something is wrong! External ID is %s, internal ID is %s",
                                 descriptor.getExternalId(), descriptor.getInternalId()))
                         ))
                 );
     }
+
+    public Mono<Descriptor> createAndSave(CollectionDescriptor collectionDescriptor) {
+        // Loading first to avoid a DuplicateKeyException which aborts a transaction.
+        // This is needed to be able to use descriptors under transaction.
+        return reactiveCollectionDescriptorService.retrieveByCoordinates(collectionDescriptor)
+                .switchIfEmpty(Mono.defer(() -> {
+                    Descriptor descriptor = savers.createCollectionDescriptor(collectionDescriptor);
+                    return reactiveDescriptorService.store(descriptor);
+                }))
+                .onErrorResume(DuplicateKeyException.class,
+                        ex -> reactiveCollectionDescriptorService.retrieveByCoordinates(collectionDescriptor))
+                .switchIfEmpty(Mono.defer(() -> Mono.error(
+                        new IllegalStateException(
+                                "Could not insert nor retrieve by collection coordinates: something is wrong!")
+                )));
+    }
+
 }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/TransactionalOnMainMongoDatabase.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/TransactionalOnMainMongoDatabase.java
@@ -1,5 +1,6 @@
 package io.extremum.mongo;
 
+import io.extremum.mongo.springdata.MainMongoDb;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.annotation.ElementType;
@@ -15,6 +16,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
-@Transactional("mainMongo")
+@Transactional(MainMongoDb.QUALIFIER)
 public @interface TransactionalOnMainMongoDatabase {
 }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/config/DescriptorsReactiveMongoConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/config/DescriptorsReactiveMongoConfiguration.java
@@ -1,20 +1,28 @@
 package io.extremum.mongo.config;
 
 import com.mongodb.WriteConcern;
-import com.mongodb.reactivestreams.client.MongoClient;
-import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 import io.extremum.mongo.properties.MongoProperties;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
+import io.extremum.mongo.springdata.MainMongoDb;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseUtils;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.WriteResultChecking;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.data.mongodb.SessionSynchronization.*;
 
 @Configuration
 @EnableConfigurationProperties(MongoProperties.class)
@@ -22,27 +30,54 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 public class DescriptorsReactiveMongoConfiguration {
     private final MongoProperties mongoProperties;
 
-    @Bean
-    public MongoClient descriptorsReactiveMongoClient() {
-        return MongoClients.create(mongoProperties.getDescriptorsDbUri());
-    }
-
     private String getDatabaseName() {
         return mongoProperties.getDescriptorsDbName();
     }
 
     @Bean
+    @DescriptorsMongoDb
     public ReactiveMongoOperations descriptorsReactiveMongoTemplate(
-            @Qualifier("descriptorsMappingMongoConverter") MappingMongoConverter mappingMongoConverter) {
-        ReactiveMongoTemplate template = new ReactiveMongoTemplate(descriptorsReactiveMongoDbFactory(),
-                mappingMongoConverter);
+            @MainMongoDb ReactiveMongoDatabaseFactory mainReactiveMongoDatabaseFactory,
+            @DescriptorsMongoDb MappingMongoConverter mappingMongoConverter) {
+        ReactiveMongoTemplate template = new ReactiveMongoTemplate(mainReactiveMongoDatabaseFactory,
+                mappingMongoConverter) {
+            // Method redefinition is required to make sure we use the correct database.
+            // Currently, spring-data-mongodb uses ReactiveMongoDatabaseFactory as a transactional resource, so we
+            // must have only one such factory, but by default ReactiveMongoTemplate uses the database configured
+            // on the factory. That's why we have to specifically switch to the needed database.
+
+            @Override
+            protected Mono<MongoDatabase> doGetDatabase() {
+                return ReactiveMongoDatabaseUtils.getDatabase(getDatabaseName(), mainReactiveMongoDatabaseFactory,
+                        ON_ACTUAL_TRANSACTION);
+            }
+
+            @Override
+            public MongoDatabase getMongoDatabase() {
+                return mainReactiveMongoDatabaseFactory.getMongoDatabase(getDatabaseName());
+            }
+
+            @Override
+            public MongoCollection<Document> getCollection(String collectionName) {
+                Assert.notNull(collectionName, "Collection name must not be null!");
+
+                try {
+                    return mainReactiveMongoDatabaseFactory.getMongoDatabase(getDatabaseName())
+                            .getCollection(collectionName);
+                } catch (RuntimeException e) {
+                    throw potentiallyConvertRuntimeException(e,
+                            mainReactiveMongoDatabaseFactory.getExceptionTranslator());
+                }
+            }
+
+            private RuntimeException potentiallyConvertRuntimeException(RuntimeException ex,
+           			PersistenceExceptionTranslator exceptionTranslator) {
+           		RuntimeException resolved = exceptionTranslator.translateExceptionIfPossible(ex);
+           		return resolved == null ? ex : resolved;
+           	}
+        };
         template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
         template.setWriteConcern(WriteConcern.MAJORITY);
         return template;
-    }
-
-    @Bean
-    public ReactiveMongoDatabaseFactory descriptorsReactiveMongoDbFactory() {
-        return new SimpleReactiveMongoDatabaseFactory(descriptorsReactiveMongoClient(), getDatabaseName());
     }
 }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainMongoConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainMongoConfiguration.java
@@ -11,6 +11,7 @@ import io.extremum.mongo.facilities.MongoDescriptorFacilitiesImpl;
 import io.extremum.mongo.properties.MongoProperties;
 import io.extremum.mongo.service.lifecycle.MongoCommonModelLifecycleListener;
 import io.extremum.mongo.springdata.EnableAllMongoAuditing;
+import io.extremum.mongo.springdata.MainMongoDb;
 import io.extremum.starter.DateToZonedDateTimeConverter;
 import io.extremum.starter.DescriptorToStringConverter;
 import io.extremum.starter.ZonedDateTimeToDateConverter;
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.convert.MappingContextTypeInformationMapper;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.WriteResultChecking;
@@ -45,12 +47,20 @@ public class MainMongoConfiguration extends AbstractMongoConfiguration {
 
     @Bean
     public MongoClientURI mongoDatabaseUri() {
-        return new MongoClientURI(mongoProperties.getServiceDbUri());
+        return new MongoClientURI(mongoProperties.getUri());
+    }
+
+    @Override
+    @Bean
+    @MainMongoDb
+    public MongoDbFactory mongoDbFactory() {
+        return super.mongoDbFactory();
     }
 
     @Override
     @Bean
     @Primary
+    @MainMongoDb
     public MongoTemplate mongoTemplate() throws Exception {
         MongoTemplate template = super.mongoTemplate();
         template.setWriteResultChecking(WriteResultChecking.EXCEPTION);
@@ -60,6 +70,7 @@ public class MainMongoConfiguration extends AbstractMongoConfiguration {
 
     @Override
     @Bean
+    @MainMongoDb
     public MongoClient mongoClient() {
         return new MongoClient(mongoDatabaseUri());
     }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainReactiveMongoConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainReactiveMongoConfiguration.java
@@ -11,9 +11,9 @@ import io.extremum.mongo.facilities.ReactiveMongoDescriptorFacilitiesImpl;
 import io.extremum.mongo.properties.MongoProperties;
 import io.extremum.mongo.service.lifecycle.ReactiveMongoCommonModelLifecycleListener;
 import io.extremum.mongo.service.lifecycle.ReactiveMongoVersionedModelLifecycleListener;
+import io.extremum.mongo.springdata.MainMongoDb;
 import io.extremum.mongo.springdata.ReactiveMongoTemplateWithReactiveEvents;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -36,7 +36,7 @@ public class MainReactiveMongoConfiguration {
 
     @Bean
     public MongoClient reactiveMongoClient() {
-        return MongoClients.create(mongoProperties.getServiceDbUri());
+        return MongoClients.create(mongoProperties.getUri());
     }
 
     private String getDatabaseName() {
@@ -45,6 +45,7 @@ public class MainReactiveMongoConfiguration {
 
     @Bean
     @Primary
+    @MainMongoDb
     public ReactiveMongoOperations reactiveMongoTemplate(MappingMongoConverter mappingMongoConverter,
                                                          ReactiveEventPublisher reactiveEventPublisher) {
         ReactiveMongoTemplateWithReactiveEvents template = new ReactiveMongoTemplateWithReactiveEvents(
@@ -55,12 +56,13 @@ public class MainReactiveMongoConfiguration {
     }
 
     @Bean
+    @MainMongoDb
     public ReactiveMongoDatabaseFactory reactiveMongoDbFactory() {
         return new SimpleReactiveMongoDatabaseFactory(reactiveMongoClient(), getDatabaseName());
     }
 
     @Bean
-    @Qualifier("mainMongo")
+    @MainMongoDb
     public ReactiveMongoTransactionManager reactiveMongoTransactionManager() {
         return new ReactiveMongoTransactionManager(reactiveMongoDbFactory());
     }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/properties/MongoProperties.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/properties/MongoProperties.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
 
+import javax.annotation.PostConstruct;
 import java.util.List;
 
 @Getter
@@ -16,10 +18,16 @@ import java.util.List;
 public class MongoProperties {
     public static final String REPOSITORY_PACKAGES_PROPERTY = "mongo.repository-packages";
 
-    private String serviceDbUri;
+    private String uri;
     private String serviceDbName;
-    private String descriptorsDbUri;
     private String descriptorsDbName;
     private List<String> repositoryPackages;
+
+    @PostConstruct
+    public void validate() {
+        if (!StringUtils.hasText(uri) || uri.contains("${")) {
+            throw new IllegalStateException(String.format("mongo.uri has not been initialized, it is '%s'", uri));
+        }
+    }
 
 }

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/DescriptorsMongoDb.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/DescriptorsMongoDb.java
@@ -1,0 +1,20 @@
+package io.extremum.mongo.springdata;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks beans related to the descriptor-related MongoDB (distinct from the main DB, for example).
+ *
+ * @author rpuch
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Qualifier(DescriptorsMongoDb.QUALIFIER)
+public @interface DescriptorsMongoDb {
+    String QUALIFIER = "descriptorsMongoDbQualifier";
+}

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/MainMongoDb.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/MainMongoDb.java
@@ -1,0 +1,20 @@
+package io.extremum.mongo.springdata;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks beans related to the main MongoDB (distinct from Descriptor-related DB, for example).
+ *
+ * @author rpuch
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Qualifier(MainMongoDb.QUALIFIER)
+public @interface MainMongoDb {
+    String QUALIFIER = "mainMongoDbQualifier";
+}

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/MongoTemplateWithFixedDatabase.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/springdata/MongoTemplateWithFixedDatabase.java
@@ -1,0 +1,29 @@
+package io.extremum.mongo.springdata;
+
+import com.mongodb.client.MongoDatabase;
+import org.springframework.data.mongodb.MongoDatabaseUtils;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+
+import static org.springframework.data.mongodb.SessionSynchronization.*;
+
+/**
+ * @author rpuch
+ */
+public class MongoTemplateWithFixedDatabase extends MongoTemplate {
+    private final MongoDbFactory mongoDbFactory;
+    private final String databaseName;
+
+    public MongoTemplateWithFixedDatabase(MongoDbFactory mongoDbFactory,
+            MappingMongoConverter mappingMongoConverter, String databaseName) {
+        super(mongoDbFactory, mappingMongoConverter);
+        this.mongoDbFactory = mongoDbFactory;
+        this.databaseName = databaseName;
+    }
+
+    @Override
+    protected MongoDatabase doGetDatabase() {
+        return MongoDatabaseUtils.getDatabase(databaseName, mongoDbFactory, ON_ACTUAL_TRANSACTION);
+    }
+}

--- a/extremum-common-starter/src/main/java/io/extremum/starter/CommonConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/starter/CommonConfiguration.java
@@ -23,6 +23,8 @@ import io.extremum.common.uuid.UUIDGenerator;
 import io.extremum.mapper.jackson.BasicJsonObjectMapper;
 import io.extremum.mongo.config.*;
 import io.extremum.mongo.reactive.MongoUniversalReactiveModelLoader;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
+import io.extremum.mongo.springdata.MainMongoDb;
 import io.extremum.sharedmodels.basic.Model;
 import io.extremum.sharedmodels.descriptor.DescriptorLoader;
 import io.extremum.starter.properties.DescriptorsProperties;
@@ -44,6 +46,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.annotation.*;
 import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -113,7 +116,7 @@ public class CommonConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public DescriptorDao descriptorDao(RedissonClient redissonClient, DescriptorRepository descriptorRepository,
-            @Qualifier("descriptorsMongoTemplate") MongoOperations descriptorMongoOperations) {
+            @DescriptorsMongoDb MongoOperations descriptorMongoOperations) {
         return DescriptorDaoFactory.create(redisProperties, descriptorsProperties,
                 redissonClient, descriptorRepository, descriptorMongoOperations);
     }
@@ -122,9 +125,10 @@ public class CommonConfiguration {
     @ConditionalOnMissingBean
     public ReactiveDescriptorDao reactiveDescriptorDao(
             RedissonReactiveClient redissonReactiveClient, DescriptorRepository descriptorRepository,
-            @Qualifier("descriptorsReactiveMongoTemplate") ReactiveMongoOperations reactiveMongoOperations) {
+            @DescriptorsMongoDb ReactiveMongoOperations reactiveMongoOperations,
+            @MainMongoDb ReactiveMongoDatabaseFactory mongoDatabaseFactory) {
         return DescriptorDaoFactory.createReactive(redisProperties, descriptorsProperties,
-                redissonReactiveClient, descriptorRepository, reactiveMongoOperations);
+                redissonReactiveClient, descriptorRepository, reactiveMongoOperations, mongoDatabaseFactory);
     }
 
     @Bean
@@ -214,8 +218,10 @@ public class CommonConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ReactiveDescriptorSaver reactiveDescriptorSaver(DescriptorService descriptorService,
-                                                           ReactiveDescriptorService reactiveDescriptorService) {
-        return new ReactiveDescriptorSaver(descriptorService, reactiveDescriptorService);
+            ReactiveDescriptorService reactiveDescriptorService,
+            ReactiveCollectionDescriptorService reactiveCollectionDescriptorService) {
+        return new ReactiveDescriptorSaver(descriptorService, reactiveDescriptorService,
+                reactiveCollectionDescriptorService);
     }
 
     @Bean

--- a/extremum-common-starter/src/main/java/io/extremum/starter/DescriptorDaoFactory.java
+++ b/extremum-common-starter/src/main/java/io/extremum/starter/DescriptorDaoFactory.java
@@ -9,6 +9,7 @@ import io.extremum.starter.properties.DescriptorsProperties;
 import io.extremum.starter.properties.RedisProperties;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.RedissonReactiveClient;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 
@@ -28,9 +29,10 @@ public class DescriptorDaoFactory {
     public static ReactiveDescriptorDao createReactive(
             RedisProperties redisProperties, DescriptorsProperties descriptorsProperties,
             RedissonReactiveClient redissonClient, DescriptorRepository descriptorRepository,
-            ReactiveMongoOperations reactiveMongoOperations) {
+            ReactiveMongoOperations reactiveMongoOperations,
+            ReactiveMongoDatabaseFactory mongoDatabaseFactory) {
         return new BaseReactiveDescriptorDaoImpl(redissonClient, descriptorRepository,
-                reactiveMongoOperations,
+                reactiveMongoOperations, mongoDatabaseFactory,
                 descriptorsProperties.getDescriptorsMapName(),
                 descriptorsProperties.getInternalIdsMapName(),
                 descriptorsProperties.getCollectionCoordinatesMapName(),

--- a/extremum-common-starter/src/test/java/descriptor/DescriptorDaoTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorDaoTest.java
@@ -8,6 +8,7 @@ import io.extremum.common.descriptor.factory.DescriptorSavers;
 import io.extremum.common.descriptor.service.DescriptorService;
 import io.extremum.common.test.TestWithServices;
 import io.extremum.mongo.facilities.MongoDescriptorFacilities;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
 import io.extremum.sharedmodels.basic.IntegerOrString;
 import io.extremum.sharedmodels.basic.StringOrMultilingual;
 import io.extremum.sharedmodels.content.Display;
@@ -26,7 +27,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.mongodb.core.MongoOperations;
@@ -38,10 +38,13 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static java.util.Collections.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 
@@ -65,7 +68,7 @@ class DescriptorDaoTest extends TestWithServices {
     @Autowired
     private DescriptorSaver descriptorSaver;
     @Autowired
-    @Qualifier("descriptorsMongoTemplate")
+    @DescriptorsMongoDb
     private MongoOperations descriptorMongoOperations;
 
     private DescriptorDao freshDaoToAvoidCachingInMemory;

--- a/extremum-common-starter/src/test/java/descriptor/DescriptorMongoStorageTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorMongoStorageTest.java
@@ -4,6 +4,7 @@ import com.mongodb.client.model.Filters;
 import config.DescriptorConfiguration;
 import io.extremum.common.descriptor.factory.DescriptorSaver;
 import io.extremum.common.test.TestWithServices;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import io.extremum.sharedmodels.descriptor.StandardStorageType;
 import org.bson.Document;
@@ -11,7 +12,6 @@ import org.bson.types.ObjectId;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoOperations;
 
@@ -19,14 +19,13 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import static descriptor.DocumentByNameMatcher.havingName;
+import static descriptor.DocumentByNameMatcher.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author rpuch
@@ -38,7 +37,7 @@ class DescriptorMongoStorageTest extends TestWithServices {
     @Autowired
     private DescriptorSaver descriptorSaver;
     @Autowired
-    @Qualifier("descriptorsMongoTemplate")
+    @DescriptorsMongoDb
     private MongoOperations mongoOperations;
 
     @Test

--- a/extremum-common-starter/src/test/java/descriptor/DescriptorRedisSerializationTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorRedisSerializationTest.java
@@ -4,9 +4,10 @@ import config.DescriptorConfiguration;
 import io.extremum.common.descriptor.dao.DescriptorDao;
 import io.extremum.common.descriptor.dao.impl.DescriptorRepository;
 import io.extremum.common.descriptor.factory.DescriptorSaver;
-import io.extremum.mongo.facilities.MongoDescriptorFacilities;
 import io.extremum.common.descriptor.service.DescriptorService;
 import io.extremum.common.test.TestWithServices;
+import io.extremum.mongo.facilities.MongoDescriptorFacilities;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
 import io.extremum.sharedmodels.descriptor.CollectionDescriptor;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import io.extremum.sharedmodels.descriptor.OwnedCoordinates;
@@ -20,18 +21,15 @@ import org.redisson.api.RMap;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoOperations;
 
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @SpringBootTest(classes = DescriptorConfiguration.class)
@@ -49,7 +47,7 @@ class DescriptorRedisSerializationTest extends TestWithServices {
     @Autowired
     private MongoDescriptorFacilities mongoDescriptorFacilities;
     @Autowired
-    @Qualifier("descriptorsMongoTemplate")
+    @DescriptorsMongoDb
     private MongoOperations descriptorMongoOperations;
     @Autowired
     private DescriptorSaver descriptorSaver;

--- a/extremum-common-starter/src/test/java/descriptor/DescriptorsStorageTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorsStorageTest.java
@@ -2,23 +2,23 @@ package descriptor;
 
 import config.DescriptorConfiguration;
 import io.extremum.common.test.TestWithServices;
+import io.extremum.mongo.springdata.DescriptorsMongoDb;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoOperations;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @SpringBootTest(classes = DescriptorConfiguration.class)
 class DescriptorsStorageTest extends TestWithServices {
     @Autowired
-    @Qualifier("descriptorsMongoTemplate")
-    private MongoOperations mongoOperations;
+    @DescriptorsMongoDb
+    private MongoOperations descriptorsMongoOperations;
 
     @Test
     void noCollectionDescriptorCollectionShouldBeCreated() {
-        assertFalse(mongoOperations.collectionExists("collectionDescriptor"));
+        assertFalse(descriptorsMongoOperations.collectionExists("collectionDescriptor"));
     }
 }

--- a/extremum-common-starter/src/test/java/io/extremum/common/collection/conversion/CollectionMakeupImplTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/collection/conversion/CollectionMakeupImplTest.java
@@ -55,11 +55,11 @@ class CollectionMakeupImplTest {
     @Spy
     private InMemoryReactiveDescriptorService reactiveDescriptorService = new InMemoryReactiveDescriptorService();
     @Spy
-    private ReactiveDescriptorSaver reactiveDescriptorSaver = new ReactiveDescriptorSaver(
-            descriptorService, reactiveDescriptorService);
-    @Spy
     private ReactiveCollectionDescriptorService reactiveCollectionDescriptorService =
             new InMemoryReactiveCollectionDescriptorService(reactiveDescriptorService, descriptorService);
+    @Spy
+    private ReactiveDescriptorSaver reactiveDescriptorSaver = new ReactiveDescriptorSaver(
+            descriptorService, reactiveDescriptorService, reactiveCollectionDescriptorService);
     @Spy
     private CollectionUrls collectionUrls = new CollectionUrlsInRoot(new TestApplicationUrls());
 

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/dao/impl/DescriptorRepositoryTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/dao/impl/DescriptorRepositoryTest.java
@@ -6,13 +6,13 @@ import common.dao.mongo.MongoCommonDaoConfiguration;
 import io.extremum.common.descriptor.service.DescriptorService;
 import io.extremum.common.test.TestWithServices;
 import io.extremum.mongo.properties.MongoProperties;
+import io.extremum.mongo.springdata.MainMongoDb;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import io.extremum.sharedmodels.descriptor.StandardStorageType;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoReactiveRepositoriesAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,10 +22,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import static com.mongodb.client.model.Filters.eq;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static com.mongodb.client.model.Filters.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
 
 /**
  * @author rpuch
@@ -39,7 +41,7 @@ class DescriptorRepositoryTest extends TestWithServices {
     private DescriptorService descriptorService;
 
     @Autowired
-    @Qualifier("descriptorsMongoClient")
+    @MainMongoDb
     private MongoClient mongoClient;
     @Autowired
     private MongoProperties mongoProperties;

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/ReactiveDescriptorSaverTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/ReactiveDescriptorSaverTest.java
@@ -11,13 +11,13 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
 
-import static io.extremum.test.mockito.ReturnFirstArgInMono.returnFirstArgInMono;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static io.extremum.test.mockito.ReturnFirstArgInMono.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author rpuch
@@ -37,6 +37,7 @@ class ReactiveDescriptorSaverTest {
     @Test
     void whenCreatingADescriptorReactiely_thenCorrectDataShouldBeSavedWithReactiveDescriptorService() {
         when(descriptorService.createExternalId()).thenReturn("external-id");
+        when(reactiveDescriptorService.loadByInternalId("internal-id")).thenReturn(Mono.empty());
         when(reactiveDescriptorService.store(any())).then(returnFirstArgInMono());
 
         descriptorSaver.createAndSave("internal-id", "Test", StandardStorageType.MONGO).block();

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/ReactiveMongoDescriptorFacilitiesImplTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/ReactiveMongoDescriptorFacilitiesImplTest.java
@@ -1,9 +1,10 @@
 package io.extremum.common.descriptor.factory.impl;
 
+import io.extremum.common.collection.conversion.InMemoryReactiveCollectionDescriptorService;
+import io.extremum.common.collection.service.ReactiveCollectionDescriptorService;
 import io.extremum.common.descriptor.factory.DescriptorFactory;
 import io.extremum.common.descriptor.factory.ReactiveDescriptorSaver;
 import io.extremum.common.descriptor.service.DescriptorService;
-import io.extremum.common.descriptor.service.ReactiveDescriptorService;
 import io.extremum.mongo.facilities.ReactiveMongoDescriptorFacilitiesImpl;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import io.extremum.sharedmodels.descriptor.StandardStorageType;
@@ -16,13 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DuplicateKeyException;
 import reactor.core.publisher.Mono;
 
-import java.util.Optional;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -36,14 +33,17 @@ class ReactiveMongoDescriptorFacilitiesImplTest {
     @Spy
     private DescriptorService descriptorService = new InMemoryDescriptorService();
     @Spy
-    private ReactiveDescriptorService reactiveDescriptorService = new InMemoryReactiveDescriptorService();
+    private InMemoryReactiveDescriptorService reactiveDescriptorService = new InMemoryReactiveDescriptorService();
+    @Spy
+    private ReactiveCollectionDescriptorService reactiveCollectionDescriptorService =
+            new InMemoryReactiveCollectionDescriptorService(reactiveDescriptorService, descriptorService);
 
     private final ObjectId objectId = new ObjectId();
 
     @BeforeEach
     void initDescriptorSaver() {
         ReactiveDescriptorSaver descriptorSaver = new ReactiveDescriptorSaver(
-                descriptorService, reactiveDescriptorService);
+                descriptorService, reactiveDescriptorService, reactiveCollectionDescriptorService);
         facilities = new ReactiveMongoDescriptorFacilitiesImpl(new DescriptorFactory(), descriptorSaver);
     }
 

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/service/StaticDescriptorLoaderAccessorTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/service/StaticDescriptorLoaderAccessorTest.java
@@ -3,11 +3,10 @@ package io.extremum.common.descriptor.service;
 import io.extremum.sharedmodels.descriptor.DescriptorLoader;
 import io.extremum.sharedmodels.descriptor.StaticDescriptorLoaderAccessor;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * @author rpuch
@@ -15,9 +14,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
 class StaticDescriptorLoaderAccessorTest {
     @Test
     void test() {
-        DescriptorLoader descriptorLoader = Mockito.mock(DescriptorLoader.class);
-        StaticDescriptorLoaderAccessor.setDescriptorLoader(descriptorLoader);
+        DescriptorLoader originalLoader = StaticDescriptorLoaderAccessor.getDescriptorLoader();
 
-        assertThat(StaticDescriptorLoaderAccessor.getDescriptorLoader(), is(sameInstance(descriptorLoader)));
+        try {
+            DescriptorLoader descriptorLoader = mock(DescriptorLoader.class);
+            StaticDescriptorLoaderAccessor.setDescriptorLoader(descriptorLoader);
+
+            assertThat(StaticDescriptorLoaderAccessor.getDescriptorLoader(), is(sameInstance(descriptorLoader)));
+        } finally {
+            StaticDescriptorLoaderAccessor.setDescriptorLoader(originalLoader);
+        }
     }
 }

--- a/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/InMemoryReactiveCollectionDescriptorService.java
+++ b/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/InMemoryReactiveCollectionDescriptorService.java
@@ -1,8 +1,7 @@
-package io.extremum.common.collection.conversion;
+package io.extremum.elasticsearch.facilities;
 
 import io.extremum.common.collection.service.ReactiveCollectionDescriptorService;
 import io.extremum.common.descriptor.factory.DescriptorSavers;
-import io.extremum.common.descriptor.factory.impl.InMemoryReactiveDescriptorService;
 import io.extremum.common.descriptor.service.DescriptorService;
 import io.extremum.sharedmodels.descriptor.CollectionDescriptor;
 import io.extremum.sharedmodels.descriptor.Descriptor;
@@ -38,12 +37,7 @@ public class InMemoryReactiveCollectionDescriptorService implements ReactiveColl
     }
 
     private Mono<Descriptor> retrieveByCoordinates(String coordinatesString) {
-        Descriptor descriptorOrNull = reactiveDescriptorService.descriptors()
-                .filter(descriptor -> descriptor.effectiveType() == Descriptor.Type.COLLECTION)
-                .filter(descriptor -> descriptor.getCollection().toCoordinatesString().equals(coordinatesString))
-                .findAny()
-                .orElse(null);
-        return Mono.justOrEmpty(descriptorOrNull);
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     private Mono<? extends Descriptor> storeCollectionDescriptor(CollectionDescriptor collectionDescriptor) {

--- a/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/ReactiveElasticsearchDescriptorFacilitiesImplTest.java
+++ b/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/ReactiveElasticsearchDescriptorFacilitiesImplTest.java
@@ -1,8 +1,8 @@
 package io.extremum.elasticsearch.facilities;
 
+import io.extremum.common.collection.service.ReactiveCollectionDescriptorService;
 import io.extremum.common.descriptor.factory.ReactiveDescriptorSaver;
 import io.extremum.common.descriptor.service.DescriptorService;
-import io.extremum.common.descriptor.service.ReactiveDescriptorService;
 import io.extremum.sharedmodels.descriptor.Descriptor;
 import io.extremum.sharedmodels.descriptor.StandardStorageType;
 import io.extremum.test.core.descriptor.InMemoryDescriptorService;
@@ -16,10 +16,9 @@ import reactor.core.publisher.Mono;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ReactiveElasticsearchDescriptorFacilitiesImplTest {
@@ -28,14 +27,17 @@ class ReactiveElasticsearchDescriptorFacilitiesImplTest {
     @Spy
     private DescriptorService descriptorService = new InMemoryDescriptorService();
     @Spy
-    private ReactiveDescriptorService reactiveDescriptorService = new InMemoryReactiveDescriptorService();
+    private InMemoryReactiveDescriptorService reactiveDescriptorService = new InMemoryReactiveDescriptorService();
+    @Spy
+    private ReactiveCollectionDescriptorService reactiveCollectionDescriptorService =
+            new InMemoryReactiveCollectionDescriptorService(reactiveDescriptorService, descriptorService);
 
     private final UUID uuid = UUID.randomUUID();
 
     @BeforeEach
     void initDescriptorSaver() {
         ReactiveDescriptorSaver descriptorSaver = new ReactiveDescriptorSaver(
-                descriptorService, reactiveDescriptorService);
+                descriptorService, reactiveDescriptorService, reactiveCollectionDescriptorService);
         facilities = new ReactiveElasticsearchDescriptorFacilitiesImpl(descriptorSaver);
     }
 

--- a/extremum-jpa-starter/src/test/java/io/extremum/jpa/facilities/StaticPostgresDescriptorFacilitiesAccessorTest.java
+++ b/extremum-jpa-starter/src/test/java/io/extremum/jpa/facilities/StaticPostgresDescriptorFacilitiesAccessorTest.java
@@ -4,8 +4,8 @@ import io.extremum.common.descriptor.factory.DescriptorFactory;
 import io.extremum.common.descriptor.factory.DescriptorSaver;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 /**
  * @author rpuch
@@ -15,10 +15,17 @@ class StaticPostgresDescriptorFacilitiesAccessorTest {
 
     @Test
     void test() {
-        PostgresDescriptorFacilities factory = new PostgresDescriptorFacilitiesImpl(new DescriptorFactory(), NOT_USED);
+        PostgresDescriptorFacilities originalFacilities = StaticPostgresDescriptorFacilitiesAccessor.getFacilities();
 
-        StaticPostgresDescriptorFacilitiesAccessor.setFacilities(factory);
+        try {
+            PostgresDescriptorFacilities factory = new PostgresDescriptorFacilitiesImpl(
+                    new DescriptorFactory(), NOT_USED);
 
-        assertThat(StaticPostgresDescriptorFacilitiesAccessor.getFacilities(), is(factory));
+            StaticPostgresDescriptorFacilitiesAccessor.setFacilities(factory);
+
+            assertThat(StaticPostgresDescriptorFacilitiesAccessor.getFacilities(), is(factory));
+        } finally {
+            StaticPostgresDescriptorFacilitiesAccessor.setFacilities(originalFacilities);
+        }
     }
 }

--- a/extremum-test-harness/src/main/java/io/extremum/test/containers/MongoContainer.java
+++ b/extremum-test-harness/src/main/java/io/extremum/test/containers/MongoContainer.java
@@ -6,15 +6,15 @@ import org.testcontainers.containers.Network;
 
 @Slf4j
 public class MongoContainer implements AutoCloseable {
-    private static final String DOCKER_IMAGE_NAME = "mongo:4.2-bionic";
+    private static final String DOCKER_IMAGE_NAME = "mongo:4.2.3-bionic";
 
     private final Network replicaSetNetwork;
-    private final GenericContainer container;
+    private final GenericContainer<?> container;
 
     public MongoContainer() {
         replicaSetNetwork = Network.newNetwork();
 
-        container = new GenericContainer(DOCKER_IMAGE_NAME)
+        container = new GenericContainer<>(DOCKER_IMAGE_NAME)
                 .withNetwork(replicaSetNetwork)
                 .withNetworkAliases("M1")
                 .withCommand("--replSet rs0 --bind_ip localhost,M1")
@@ -24,12 +24,11 @@ public class MongoContainer implements AutoCloseable {
         initReplicaSet(container);
 
         String mongoUri = "mongodb://" + container.getContainerIpAddress() + ":" + container.getFirstMappedPort();
-        System.setProperty("mongo.serviceDbUri", mongoUri);
-        System.setProperty("mongo.descriptorsDbUri", mongoUri);
+        System.setProperty("mongo.uri", mongoUri);
         log.info("MongoDB uri is {}", mongoUri);
     }
 
-    private static void initReplicaSet(GenericContainer mongo) {
+    private static void initReplicaSet(GenericContainer<?> mongo) {
         try {
             mongo.execInContainer("/bin/bash", "-c",
                     "mongo --eval 'printjson(rs.initiate({_id:\"rs0\","


### PR DESCRIPTION
…ransaction

- use only one database factory as it is used as a transactional resource by spring-data-mongodb
- as such, only use one MongoDB connection string in the configuration
- get rid of 'insert-and-get-if-duplicate-exception-occurs' pattern inside transaction as a duplication error aborts a transaction and it becomes impossible to recover
- when making a descriptor ready, write descriptor to Redis only after the MongoDB transaction has committed successfully to avoid the descriptor activation to be visible before the entity 'described' by the descriptor becomes visible due to transaction commit
- use a custom qualifier annotation instead of qualifying by bean name