### PR TITLE
CS-1378 Store UUIDs in MongoDB using Standard representation

### DIFF
--- a/extremum-bom/pom.xml
+++ b/extremum-bom/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <spring-boot-dependencies.version>2.2.4.RELEASE</spring-boot-dependencies.version>
+        <mongodb-driver.version>3.12.7</mongodb-driver.version>
         <elasticsearch.version>7.1.0</elasticsearch.version>
         <testcontainers.version>1.11.3</testcontainers.version>
         <mock-server.client.version>5.5.1</mock-server.client.version>
@@ -110,6 +111,22 @@
                 <groupId>io.extremum</groupId>
                 <artifactId>extremum-everything-dynamic</artifactId>
                 <version>1.1.13-SNAPSHOT</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver</artifactId>
+                <version>${mongodb-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-core</artifactId>
+                <version>${mongodb-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>bson</artifactId>
+                <version>${mongodb-driver.version}</version>
             </dependency>
 
             <dependency>

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainMongoConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainMongoConfiguration.java
@@ -1,5 +1,7 @@
 package io.extremum.mongo.config;
 
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.WriteConcern;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -17,6 +19,7 @@ import io.extremum.starter.DateToZonedDateTimeConverter;
 import io.extremum.starter.DescriptorToStringConverter;
 import io.extremum.starter.ZonedDateTimeToDateConverter;
 import lombok.RequiredArgsConstructor;
+import org.bson.UuidRepresentation;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -72,7 +75,11 @@ public class MainMongoConfiguration extends AbstractMongoClientConfiguration {
     @Bean
     @MainMongoDb
     public MongoClient mongoClient() {
-        return MongoClients.create(mongoProperties.getUri());
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(mongoProperties.getUri()))
+                .uuidRepresentation(UuidRepresentation.STANDARD)
+                .build();
+        return MongoClients.create(settings);
     }
 
     @Override

--- a/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainReactiveMongoConfiguration.java
+++ b/extremum-common-starter/src/main/java/io/extremum/mongo/config/MainReactiveMongoConfiguration.java
@@ -1,5 +1,7 @@
 package io.extremum.mongo.config;
 
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
 import com.mongodb.WriteConcern;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
@@ -14,6 +16,7 @@ import io.extremum.mongo.service.lifecycle.ReactiveMongoVersionedModelLifecycleL
 import io.extremum.mongo.springdata.MainMongoDb;
 import io.extremum.mongo.springdata.ReactiveMongoTemplateWithReactiveEvents;
 import lombok.RequiredArgsConstructor;
+import org.bson.UuidRepresentation;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -36,7 +39,11 @@ public class MainReactiveMongoConfiguration {
 
     @Bean
     public MongoClient reactiveMongoClient() {
-        return MongoClients.create(mongoProperties.getUri());
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(mongoProperties.getUri()))
+                .uuidRepresentation(UuidRepresentation.STANDARD)
+                .build();
+        return MongoClients.create(settings);
     }
 
     private String getDatabaseName() {


### PR DESCRIPTION
According to https://studio3t.com/knowledge-base/articles/mongodb-best-practices-uuid-data/ , code 3 is now considered as Legacy, as it is not portable. It is recommended to use code 4 (Standard). By default, Java driver uses code 3, we need to switch to code 4 for more reliability.