### PR TITLE
CS-1385 Make json serialization of enums consistent

### DIFF
--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/MultilingualLanguage.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/MultilingualLanguage.java
@@ -1,5 +1,8 @@
 package io.extremum.sharedmodels.basic;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * IETF language tags in the format defined by RFC 5646 (language-TERRITORY).
  */
@@ -160,10 +163,12 @@ public enum MultilingualLanguage {
         this.value = value;
     }
 
+    @JsonValue
     public String getValue() {
         return value;
     }
 
+    @JsonCreator
     public static MultilingualLanguage fromString(String value) {
         if (value != null) {
             for (MultilingualLanguage item : MultilingualLanguage.values()) {


### PR DESCRIPTION
Current mapper implementation has a couple of problems:

* It ignores standard Jackson mechanisms (@JjsonProperty, @JsonValue, @JsonCreator) to modify (de)serialization
* It always serializes enums to lowercase, but deserializes either converting to uppercase or using static fromString() method which seems inconsistent

The best way (implemented in this commit) would be to have this:

* If an enum is annotated with any of standard Jackson annotations, still use the corresponding behavior
* If it is not annotated, only then use lowercase representation

WARNING: this removes the old behavior deserialization of enums using fromString() method. All such methods should be annotated with @JsonCreator to work.