### PR TITLE
CS-1386 Remove enum serialization customizations

### DIFF
--- a/extremum-everything-core/src/test/java/io/extremum/everything/aop/DefaultEverythingEverythingExceptionHandlerTest.java
+++ b/extremum-everything-core/src/test/java/io/extremum/everything/aop/DefaultEverythingEverythingExceptionHandlerTest.java
@@ -52,7 +52,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
     void whenNothingIsThrown_thenOriginalResponseShouldBeReturned() throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/ok");
 
-        assertThat(root.getString("status"), is("OK"));
+        assertThat(root.getString("status"), is("ok"));
         assertThat(root.getInt("code"), is(200));
         assertThat(root.getString("result"), is("Success!"));
     }
@@ -68,7 +68,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/model-not-found");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(404));
         assertThat(root.getString("result"), is(nullValue()));
     }
@@ -86,7 +86,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/evr-evr-exception");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(500));
         assertThat(root.getString("result"), is(nullValue()));
     }
@@ -96,7 +96,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/validation-failure");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(400));
         assertThat(root.getString("result"), is("Unable to complete 'everything-everything' operation"));
     }
@@ -106,7 +106,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/descriptor-not-found");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(404));
         assertThat(root.getString("result"), is(nullValue()));
     }
@@ -116,7 +116,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/descriptor-not-ready");
 
-        assertThat(root.getString("status"), is("DOING"));
+        assertThat(root.getString("status"), is("doing"));
         assertThat(root.getInt("code"), is(102));
         assertThat(root.getString("result"), is(nullValue()));
         JSONArray alerts = root.getJSONArray("alerts");
@@ -131,7 +131,7 @@ class DefaultEverythingEverythingExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/extremum-access-denied-exception");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(403));
         assertThat(root.getString("result"), is(nullValue()));
     }

--- a/extremum-jackson-mapper/src/main/java/io/extremum/mapper/jackson/module/BasicSerializationDeserializationModule.java
+++ b/extremum-jackson-mapper/src/main/java/io/extremum/mapper/jackson/module/BasicSerializationDeserializationModule.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.introspect.NopAnnotationIntrospector;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import io.extremum.mapper.jackson.deserializer.DisplayDeserializer;
@@ -62,17 +61,6 @@ public class BasicSerializationDeserializationModule extends SimpleModule {
         addDeserializer(Pagination.class, new PaginationDeserializer(mapper));
     }
 
-    @Override
-    public void setupModule(SetupContext context) {
-        super.setupModule(context);
-
-        addLowercasingEnumIntrospectorWithPriorityLowerThanStandard(context);
-    }
-
-    private void addLowercasingEnumIntrospectorWithPriorityLowerThanStandard(SetupContext context) {
-        context.appendAnnotationIntrospector(new LowercasingEnumAnnotationIntrospector());
-    }
-
     private static class ObjectIdDeserializer extends StdDeserializer<ObjectId> {
         ObjectIdDeserializer() {
             super(ObjectId.class);
@@ -81,18 +69,6 @@ public class BasicSerializationDeserializationModule extends SimpleModule {
         @Override
         public ObjectId deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
             return new ObjectId(p.getValueAsString());
-        }
-    }
-
-    private static class LowercasingEnumAnnotationIntrospector extends NopAnnotationIntrospector {
-        @Override
-        public String[] findEnumValues(Class<?> enumType, Enum<?>[] enumValues, String[] names) {
-            for (int i = 0; i < enumValues.length; i++) {
-                if (names[i] == null) {
-                    names[i] = enumValues[i].name().toLowerCase();
-                }
-            }
-            return names;
         }
     }
 }

--- a/extremum-jackson-mapper/src/test/java/io/extremum/mapper/jackson/BasicJsonObjectMapperTest.java
+++ b/extremum-jackson-mapper/src/test/java/io/extremum/mapper/jackson/BasicJsonObjectMapperTest.java
@@ -150,13 +150,13 @@ class BasicJsonObjectMapperTest {
     }
 
     @Test
-    void shouldSerializeBareEnumAsFieldLowerCase() throws Exception {
-        assertThat(mapper.writeValueAsString(BareEnum.VALUE), is("\"value\""));
+    void shouldSerializeBareEnumAsFieldName() throws Exception {
+        assertThat(mapper.writeValueAsString(BareEnum.VALUE), is("\"VALUE\""));
     }
 
     @Test
-    void shouldDeserializeBareEnumFromFieldLowerCase() throws Exception {
-        assertThat(mapper.readValue("\"value\"", BareEnum.class), is(BareEnum.VALUE));
+    void shouldDeserializeBareEnumFromFieldName() throws Exception {
+        assertThat(mapper.readValue("\"VALUE\"", BareEnum.class), is(BareEnum.VALUE));
     }
 
     @Test

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/IntegerOrString.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/IntegerOrString.java
@@ -39,6 +39,9 @@ public class IntegerOrString implements Serializable {
     }
 
     private enum Type {
-        NUMBER, STRING
+        @JsonProperty("number")
+        NUMBER,
+        @JsonProperty("string")
+        STRING
     }
 }

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/StringOrMultilingual.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/basic/StringOrMultilingual.java
@@ -1,5 +1,6 @@
 package io.extremum.sharedmodels.basic;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -51,7 +52,12 @@ public class StringOrMultilingual implements Serializable {
     }
 
     public enum Type {
-        UNKNOWN, TEXT, MAP
+        @JsonProperty("unknown")
+        UNKNOWN,
+        @JsonProperty("text")
+        TEXT,
+        @JsonProperty("map")
+        MAP
     }
 
     public enum FIELDS {

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/content/Display.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/content/Display.java
@@ -48,7 +48,10 @@ public class Display implements Serializable {
     }
 
     public enum Type {
-        STRING, OBJECT
+        @JsonProperty("string")
+        STRING,
+        @JsonProperty("object")
+        OBJECT
     }
 
     public enum FIELDS {

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/content/MediaType.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/content/MediaType.java
@@ -13,7 +13,7 @@ public enum MediaType {
     IMAGE_GIF("image/gif"),
     IMAGE_PNG("image/png");
 
-    private String value;
+    private final String value;
 
     MediaType(String value) {
         this.value = value;

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/descriptor/CollectionDescriptor.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/descriptor/CollectionDescriptor.java
@@ -1,5 +1,6 @@
 package io.extremum.sharedmodels.descriptor;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.io.Serializable;
@@ -63,6 +64,7 @@ public final class CollectionDescriptor implements Serializable {
         /**
          * Collection is identified by host (owning) entity and host field name.
          */
+        @JsonProperty("owned")
         OWNED {
             @Override
             String toCoordinatesString(CollectionCoordinates coordinates) {
@@ -72,6 +74,7 @@ public final class CollectionDescriptor implements Serializable {
         /**
          * Collection is identified by name (and optional parameter string).
          */
+        @JsonProperty("free")
         FREE {
             @Override
             String toCoordinatesString(CollectionCoordinates coordinates) {

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/dto/AlertLevelEnum.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/dto/AlertLevelEnum.java
@@ -11,7 +11,7 @@ public enum  AlertLevelEnum {
     ERROR("error"),
     FATAL("fatal");
 
-    private String value;
+    private final String value;
 
     AlertLevelEnum (String value) {
         this.value = value;

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/dto/ResponseStatusEnum.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/dto/ResponseStatusEnum.java
@@ -1,7 +1,7 @@
 package io.extremum.sharedmodels.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum ResponseStatusEnum {
     /**
@@ -24,13 +24,13 @@ public enum ResponseStatusEnum {
      */
     FAIL("fail");
 
-    private String value;
+    private final String value;
 
     ResponseStatusEnum (String value) {
         this.value = value;
     }
 
-    @JsonGetter
+    @JsonValue
     public String getValue() {
         return this.value;
     }

--- a/extremum-watch-starter/src/test/java/io/extremum/watch/controller/WatchControllersExceptionHandlerTest.java
+++ b/extremum-watch-starter/src/test/java/io/extremum/watch/controller/WatchControllersExceptionHandlerTest.java
@@ -42,7 +42,7 @@ class WatchControllersExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/extremum-access-denied-exception");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(403));
         assertThat(root.getString("result"), is(nullValue()));
     }
@@ -66,7 +66,7 @@ class WatchControllersExceptionHandlerTest {
             throws Exception {
         JSONObject root = getSuccessfullyAndParseResponse("/watch-exception");
 
-        assertThat(root.getString("status"), is("FAIL"));
+        assertThat(root.getString("status"), is("fail"));
         assertThat(root.getInt("code"), is(500));
         assertThat(root.getString("result"), is(nullValue()));
     }


### PR DESCRIPTION
As our ObjectMapper is used globally in an application, it should only modify the standard Jackson behavior in additive ways. Enum serialization was modified in Extremum in non-additive way, and it is easily reconstructed in application code using annotations, so it should be removed from Extremum.