### PR TITLE
CS-1387 Add ability to totally delete descriptor

### DIFF
--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/service/ReactiveDescriptorService.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/service/ReactiveDescriptorService.java
@@ -16,4 +16,6 @@ public interface ReactiveDescriptorService {
     Mono<Map<String, String>> loadMapByInternalIds(Collection<String> internalIds);
 
     Mono<Descriptor> makeDescriptorReady(String descriptorExternalId, String modelType);
+
+    Mono<Void> destroyDescriptor(String externalId);
 }

--- a/extremum-common-starter/src/main/java/io/extremum/common/descriptor/service/ReactiveDescriptorServiceImpl.java
+++ b/extremum-common-starter/src/main/java/io/extremum/common/descriptor/service/ReactiveDescriptorServiceImpl.java
@@ -60,4 +60,9 @@ public class ReactiveDescriptorServiceImpl implements ReactiveDescriptorService 
                 })
                 .flatMap(reactiveDescriptorDao::store);
     }
+
+    @Override
+    public Mono<Void> destroyDescriptor(String externalId) {
+        return reactiveDescriptorDao.destroy(externalId);
+    }
 }

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/InMemoryReactiveDescriptorDao.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/InMemoryReactiveDescriptorDao.java
@@ -36,4 +36,9 @@ public class InMemoryReactiveDescriptorDao implements ReactiveDescriptorDao {
         descriptorMap.put(descriptor.getExternalId(), descriptor);
         return Mono.just(descriptor);
     }
+
+    @Override
+    public Mono<Void> destroy(String externalId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/InMemoryReactiveDescriptorService.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/factory/impl/InMemoryReactiveDescriptorService.java
@@ -57,7 +57,12 @@ public class InMemoryReactiveDescriptorService implements ReactiveDescriptorServ
 
     @Override
     public Mono<Descriptor> makeDescriptorReady(String descriptorExternalId, String modelType) {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Mono<Void> destroyDescriptor(String externalId) {
+        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     public Stream<Descriptor> descriptors() {

--- a/extremum-common-starter/src/test/java/io/extremum/common/descriptor/service/ReactiveDescriptorServiceImplTest.java
+++ b/extremum-common-starter/src/test/java/io/extremum/common/descriptor/service/ReactiveDescriptorServiceImplTest.java
@@ -146,4 +146,13 @@ class ReactiveDescriptorServiceImplTest {
                 .expectError(DescriptorIsAlreadyReadyException.class)
                 .verify();
     }
+
+    @Test
+    void shouldRelayDestroyRequestToDao() {
+        when(reactiveDescriptorDao.destroy("external-id")).thenReturn(Mono.empty());
+
+        reactiveDescriptorService.destroyDescriptor("external-id").block();
+
+        verify(reactiveDescriptorDao).destroy("external-id");
+    }
 }

--- a/extremum-descriptors/reactive/src/main/java/io/extremum/descriptors/reactive/dao/ReactiveDescriptorDao.java
+++ b/extremum-descriptors/reactive/src/main/java/io/extremum/descriptors/reactive/dao/ReactiveDescriptorDao.java
@@ -17,4 +17,5 @@ public interface ReactiveDescriptorDao {
 
     Mono<Descriptor> store(Descriptor descriptor);
 
+    Mono<Void> destroy(String externalId);
 }

--- a/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/InMemoryReactiveDescriptorService.java
+++ b/extremum-elasticsearch-starter/src/test/java/io/extremum/elasticsearch/facilities/InMemoryReactiveDescriptorService.java
@@ -60,6 +60,11 @@ public class InMemoryReactiveDescriptorService implements ReactiveDescriptorServ
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public Mono<Void> destroyDescriptor(String externalId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
     public Stream<Descriptor> descriptors() {
         return externalIdToDescriptorMap.values().stream();
     }


### PR DESCRIPTION
Sometimes, it is required to destroy a descriptor compeletely. For instance, this applies to descriptors for which we know that they will remain blank forever.