### PR TITLE
CS-1390 Remove equals and hashCode methods from Descriptor

### DIFF
--- a/extremum-common-starter/src/test/java/descriptor/DescriptorDaoTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorDaoTest.java
@@ -175,7 +175,8 @@ class DescriptorDaoTest extends TestWithServices {
         descriptorMongoOperations.save(descriptor);
         retrievedDescriptor = descriptorDao.retrieveByInternalId(internalId);
         assertTrue(retrievedDescriptor.isPresent());
-        assertEquals(descriptor, retrievedDescriptor.get());
+        assertEquals(descriptor.getExternalId(), retrievedDescriptor.get().getExternalId());
+        assertEquals(descriptor.getInternalId(), retrievedDescriptor.get().getInternalId());
     }
 
     @NotNull

--- a/extremum-common-starter/src/test/java/descriptor/DescriptorRedisSerializationTest.java
+++ b/extremum-common-starter/src/test/java/descriptor/DescriptorRedisSerializationTest.java
@@ -75,7 +75,8 @@ class DescriptorRedisSerializationTest extends TestWithServices {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private void assertThatRetrievedDescriptorIsOk(Descriptor descriptor, Optional<Descriptor> retrievedDescriptor) {
         assertTrue(retrievedDescriptor.isPresent());
-        assertEquals(descriptor, retrievedDescriptor.get());
+        assertEquals(descriptor.getExternalId(), retrievedDescriptor.get().getExternalId());
+        assertEquals(descriptor.getInternalId(), retrievedDescriptor.get().getInternalId());
     }
 
     @Test

--- a/extremum-shared-models/src/main/java/io/extremum/sharedmodels/descriptor/Descriptor.java
+++ b/extremum-shared-models/src/main/java/io/extremum/sharedmodels/descriptor/Descriptor.java
@@ -8,12 +8,15 @@ import io.extremum.common.annotation.FromStorageString;
 import io.extremum.common.annotation.ToStorageString;
 import io.extremum.sharedmodels.annotation.UsesStaticDependencies;
 import io.extremum.sharedmodels.content.Display;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import reactor.core.publisher.Mono;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Objects;
 
 @Builder
 @Getter
@@ -310,26 +313,6 @@ public class Descriptor implements Serializable {
         } else {
             throw new IllegalStateException("Both externalId and internalId are null");
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Descriptor that = (Descriptor) o;
-        return Objects.equals(getExternalId(), that.getExternalId()) &&
-                Objects.equals(getInternalId(), that.getInternalId()) &&
-                Objects.equals(getModelType(), that.getModelType()) &&
-                Objects.equals(getStorageType(), that.getStorageType());
-    }
-
-    @Override
-    public int hashCode() {
-        return this.getExternalId().hashCode();
     }
 
     @Override


### PR DESCRIPTION
There are cases when we cannot say that descriptors are equal or not without resolving them, which requires to go to a database. And it is an absolute evil to go to a database from a hashCode() method. Plus this does not play well with reactive environments at all.

Such a ‘non-comparable’ descriptors example: one of the descriptors only has externalId, and another one only has internalId loaded.

The clients are better off to compare descriptors themselves if they need this (probably in a wrapper) making sure that the descriptors are fully resolved.